### PR TITLE
maps/portfolio - get site url in plugin file

### DIFF
--- a/wp-content/plugins/Hotel-Portfolio/assets/portfolio-template.js
+++ b/wp-content/plugins/Hotel-Portfolio/assets/portfolio-template.js
@@ -696,16 +696,12 @@
             // Remove old data-url
             mapViewBtn.removeAttribute("data-url");
 
-           // Get the base path (e.g., "/hrgredesign")
-            const pathSegments = window.location.pathname.split('/').filter(Boolean); // remove empty segments
-            const basePath = pathSegments.length > 0 ? `/${pathSegments[0]}` : '/';
-
             // Get URL parameters
             const urlParams = new URLSearchParams(window.location.search);
             const hasParams = [...urlParams.values()].some(value => value && value.trim() !== "");
 
             // Start with base path
-            let finalUrl = basePath +"/maps/";
+            let finalUrl = hotelPortfolio.siteUrl +"/maps/";
             if (hasParams) {
                 finalUrl += `?${urlParams.toString()}`;
             }

--- a/wp-content/plugins/Hotel-Portfolio/hotel-portfolio.php
+++ b/wp-content/plugins/Hotel-Portfolio/hotel-portfolio.php
@@ -117,7 +117,8 @@ function hotel_portfolio_enqueue_scripts() {
         wp_enqueue_script('hotel-portfolio-ajax', HOTEL_PORTFOLIO_URL . 'assets/portfolio-template.js', array('jquery'), null, true);
         
         wp_localize_script('hotel-portfolio-ajax', 'hotelPortfolio', array(
-            'ajaxurl' => admin_url('admin-ajax.php')
+            'ajaxurl' => admin_url('admin-ajax.php'),
+            'siteUrl' => home_url()
         ));
 
         wp_enqueue_style('hotel-portfolio-filter', HOTEL_PORTFOLIO_URL . 'assets/hotelfilter/filter.css', array(), HOTEL_PORTFOLIO_VERSION);


### PR DESCRIPTION
it is useful to get the home url in the plugin file for staging, local and the life enviroment. 
Also for the different urls (portrolio/hotels, meeting-events ).
i add it in wp_localize_script and store it as js var hotelPortfolio.siteUrl