### PR TITLE
maps - change the way to render in first place

### DIFF
--- a/wp-content/plugins/revo-hotels-maps/assets/maps-template.js
+++ b/wp-content/plugins/revo-hotels-maps/assets/maps-template.js
@@ -173,11 +173,7 @@ function initRevoHotelsMap() {
             });
 
             console.log('window.isMice: '+ window.isMice);
-            generateDropdownOptions(allHotels);
-            renderMarkers(allHotels);
             checkParams();
-            updateGridViewBtn();  
-            addMiceStylesIfNeeded();
         });
 }
 // add styles if isMice is true
@@ -208,6 +204,16 @@ function checkParams() {
         if (people) document.getElementById('people-header').value = people;
 
         filterMarkers();        // Your filtering function
+    }else {
+        // If no params, reset the map and markers
+        zoomOut();
+        clearMarkers();
+        updateResultMessage(allHotels.length, allHotels);
+        renderMarkers(allHotels); // Render all hotels
+        generateDropdownOptions(allHotels); // Generate dropdown options from all hotels
+        updateGridViewBtn();  
+        addMiceStylesIfNeeded();
+
     }
 }
 // Update grid view button based on URL parameters


### PR DESCRIPTION
I changed the rendering of the maps in the first place because I got the wrong result when I called the site from outside with parameters. Now, the checkParamater() function is called first, and I added an if-else statement to it that calls all functions depending on the parameters.